### PR TITLE
Fix plugin packaging and balance permission

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'com.gradleup.shadow' version '8.3.0'
 }
 
 group = 'io.github.HenriqueMichelini'
@@ -24,19 +23,22 @@ dependencies {
 
     // Shaded libs
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }
 
-shadowJar {
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier.set('')
+    from {
+        configurations.runtimeClasspath.collect { dependency ->
+            dependency.isDirectory() ? dependency : zipTree(dependency)
+        }
+    }
     exclude 'org/mockbukkit/**'
     exclude 'junit/**'
     exclude 'org/junit/**'
     exclude 'org/mockito/**'
-
-    relocate 'com.github.benmanes.caffeine', 'io.github.HenriqueMichelini.craftalism_economy.libs.caffeine'
-    relocate 'org.apache.http', 'io.github.HenriqueMichelini.craftalism_economy.libs.apache.http'
-
-    archiveClassifier.set('shadow')
 }
 
 

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism.economy/CraftalismEconomy.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism.economy/CraftalismEconomy.java
@@ -16,16 +16,20 @@ public final class CraftalismEconomy extends JavaPlugin {
         reloadConfig();
 
         this.container = new BootContainer(this, this);
-
-        this.container.initialize();
-
-
-        getLogger().info("Plugin enabled successfully");
+        try {
+            this.container.initialize();
+            getLogger().info("Plugin enabled successfully");
+        } catch (RuntimeException exception) {
+            getLogger().severe("Failed to enable CraftalismEconomy: " + exception.getMessage());
+            throw exception;
+        }
     }
 
     @Override
     public void onDisable() {
-        container.shutdown();
+        if (container != null) {
+            container.shutdown();
+        }
     }
 
     public CurrencyFormatter getCurrencyFormatter() {

--- a/java/src/main/resources/plugin.yml
+++ b/java/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ commands:
   balance:
     description: Check your balance.
     usage: /balance or /balance <player>
-    permission: craftalism.balance
+    permission: craftalism.balance.self
     permission-message: You do not have permission to use this command.
   setbalance:
     description: Set a player's balance (console/ops only).


### PR DESCRIPTION
### Motivation
- The plugin could fail at startup on servers when runtime libraries used during initialization are not present in the deployed jar, causing the plugin to be disabled when commands are executed. 
- The `balance` command in `plugin.yml` referenced a nonexistent permission node which can prevent normal self-balance usage even if the plugin enables.
- The plugin lifecycle needed to be hardened to avoid null-pointer shutdowns and to provide clearer enable failure logs.

### Description
- Updated `java/build.gradle` so the default `jar` task bundles runtime dependencies into the produced jar by collecting `configurations.runtimeClasspath` and excluding test/mock libraries, and added `gson` as an explicit implementation dependency. 
- Removed reliance on an external shadow plugin and implemented an embedded-dependency strategy in the `jar` task with `duplicatesStrategy` and exclusion rules. 
- Fixed `java/src/main/resources/plugin.yml` so the `/balance` command uses the declared `craftalism.balance.self` permission node instead of `craftalism.balance`. 
- Hardened `CraftalismEconomy.onEnable` to log enable failures and rethrow, and made `onDisable` null-safe by checking the container before calling `shutdown`.

### Testing
- Ran `git diff --check` which passed with no whitespace or patch issues. 
- Ran configuration assertions with a short Python script that verified the `plugin.yml` permission change and the `build.gradle` dependency/jar bundling edits which succeeded. 
- Attempted `./gradlew test` and `./gradlew jar` in this environment but both were blocked by external Maven repository HTTP 403 responses so dependency resolution could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be3b4349c483239cdfcba9899b7074)