### PR TITLE
Bundle runtime dependencies into plugin JAR and align project version

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'io.github.HenriqueMichelini'
-version = '1.2-SNAPSHOT'
+version = '1.3'
 
 repositories {
     mavenCentral()
@@ -28,19 +28,11 @@ dependencies {
 }
 
 tasks.jar {
-    archiveClassifier.set('')
-}
-
-tasks.register('fatJar', Jar) {
-    group = 'build'
-    description = 'Builds the plugin jar with bundled runtime dependencies.'
-    archiveClassifier.set('all')
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn configurations.runtimeClasspath
+    archiveClassifier.set('')
 
     from sourceSets.main.output
-    dependsOn configurations.runtimeClasspath
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    archiveClassifier.set('')
     from {
         configurations.runtimeClasspath.collect { dependency ->
             dependency.isDirectory() ? dependency : zipTree(dependency)
@@ -51,10 +43,6 @@ tasks.register('fatJar', Jar) {
     exclude 'junit/**'
     exclude 'org/junit/**'
     exclude 'org/mockito/**'
-}
-
-tasks.assemble {
-    dependsOn tasks.named('fatJar')
 }
 
 


### PR DESCRIPTION
### Motivation
- Fix a runtime `NoClassDefFoundError` for `com.github.benmanes.caffeine.cache.Caffeine` caused by deploying a thin plugin JAR that did not include implementation dependencies.
- Ensure the build metadata matches the shipped plugin metadata so artifacts and plugin.yml stay in sync.

### Description
- Updated the Gradle project version from `1.2-SNAPSHOT` to `1.3` in `java/build.gradle` to match `plugin.yml`.
- Removed the separate `fatJar`/`assemble` indirection and folded dependency bundling into the standard `jar` task (`tasks.jar`) so the runtime classpath is packaged into the plugin artifact.
- Kept test and mocking libraries excluded from the packaged artifact by explicitly excluding test-related packages when building the jar.

### Testing
- Verified Gradle can run in the repository using JDK 21 with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH="$JAVA_HOME/bin:$PATH" ./gradlew help -q` which completed successfully.
- Attempted `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH="$JAVA_HOME/bin:$PATH" ./gradlew jar -m` to exercise the jar packaging, but dependency resolution failed in this environment because configured Maven repositories returned HTTP 403 responses, preventing a full artifact build and verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c064c07fe88323a045890af2e9d769)