### PR TITLE
Fix async exception unwrapping, API deposit/withdraw paths, and BalanceCommand formatting

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
@@ -5,11 +5,11 @@ import io.github.HenriqueMichelini.craftalism.economy.infra.api.dto.BalanceRespo
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.exceptions.NotFoundException;
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.repository.BalanceCacheRepository;
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.BalanceApiService;
-import io.github.HenriqueMichelini.craftalism.economy.infra.config.ConfigLoader;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 public class BalanceApplicationService {
 
@@ -100,11 +100,24 @@ public class BalanceApplicationService {
     }
 
     private boolean isNotFoundException(Throwable ex) {
-        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-        return cause instanceof NotFoundException;
+        return unwrap(ex) instanceof NotFoundException;
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while (
+            current instanceof CompletionException ||
+            current instanceof ExecutionException
+        ) {
+            if (current.getCause() == null) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return current;
     }
 
     private <T> T throwAsCompletion(Throwable ex) {
-        throw new CompletionException(ex);
+        throw new CompletionException(unwrap(ex));
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
@@ -10,6 +10,8 @@ import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.PlayerAp
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 public class PlayerApplicationService {
     private final PlayerApiService api;
@@ -72,10 +74,11 @@ public class PlayerApplicationService {
     public CompletableFuture<PlayerResponseDTO> getOrCreatePlayer(UUID uuid, String name) {
         return api.getPlayerByUuid(uuid)
                 .exceptionallyCompose(ex -> {
-                    if (ex instanceof NotFoundException || ex instanceof ApiServerException) {
+                    Throwable cause = unwrap(ex);
+                    if (cause instanceof NotFoundException || cause instanceof ApiServerException) {
                         return api.createPlayer(uuid, name);
                     }
-                    return CompletableFuture.failedFuture(ex);
+                    return CompletableFuture.failedFuture(cause);
                 });
     }
 
@@ -91,5 +94,16 @@ public class PlayerApplicationService {
                     cache.save(player);
                     return player;
                 });
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while (current instanceof CompletionException || current instanceof ExecutionException) {
+            if (current.getCause() == null) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return current;
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/infra/api/service/BalanceApiService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/infra/api/service/BalanceApiService.java
@@ -126,7 +126,10 @@ public class BalanceApiService {
     public CompletableFuture<Void> deposit(UUID uuid, long amount) {
         BalanceUpdateRequestDTO dto = new BalanceUpdateRequestDTO(amount);
         return http
-            .post("/api/balances/" + uuid + "/deposit", gson.toJson(dto))
+            .post(
+                "/api/balances/" + uuid + "/deposit?amount=" + amount,
+                gson.toJson(dto)
+            )
             .thenCompose(resp -> {
                 int status = resp.statusCode();
                 String body = resp.body();
@@ -144,7 +147,10 @@ public class BalanceApiService {
     public CompletableFuture<Void> withdraw(UUID uuid, long amount) {
         BalanceUpdateRequestDTO dto = new BalanceUpdateRequestDTO(amount);
         return http
-            .post("/api/balances/" + uuid + "/withdraw", gson.toJson(dto))
+            .post(
+                "/api/balances/" + uuid + "/withdraw?amount=" + amount,
+                gson.toJson(dto)
+            )
             .thenCompose(resp -> {
                 int status = resp.statusCode();
                 String body = resp.body();

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/BalanceCommand.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/BalanceCommand.java
@@ -82,12 +82,13 @@ public class BalanceCommand implements CommandExecutor {
     }
 
     private void handleResult(Player sender, BalanceExecutionResult result, String targetName) {
+        String formattedAmount = formatAmount(result.amount());
         switch (result.status()) {
             case SUCCESS_SELF ->
-                    messages.sendBalanceSelfSuccess(sender, formatter.formatCurrency(result.amount()));
+                    messages.sendBalanceSelfSuccess(sender, formattedAmount);
 
             case SUCCESS_OTHER ->
-                    messages.sendBalanceOtherSuccess(sender, targetName, formatter.formatCurrency(result.amount()));
+                    messages.sendBalanceOtherSuccess(sender, targetName, formattedAmount);
 
             case NO_BALANCE ->
                     messages.sendBalanceOtherNoBalance(sender, targetName);
@@ -98,5 +99,14 @@ public class BalanceCommand implements CommandExecutor {
             default ->
                     messages.sendBalanceError(sender);
         }
+    }
+
+    private String formatAmount(Long amount) {
+        if (amount == null) {
+            return "0";
+        }
+
+        String formatted = formatter.formatCurrency(amount);
+        return formatted != null ? formatted : String.valueOf(amount);
     }
 }


### PR DESCRIPTION
### Motivation
- Address multiple unit test failures caused by async exceptions being wrapped (so `NotFoundException`/`ApiServerException` were not detected) and by API request path mismatches and null formatter output.
- Ensure the application treats wrapped completion exceptions consistently so service methods behave as tests expect when upstream futures complete exceptionally.

### Description
- Updated `PlayerApplicationService#getOrCreatePlayer` to unwrap nested `CompletionException`/`ExecutionException` causes and only call `api.createPlayer` when the unwrapped cause is a `NotFoundException` or `ApiServerException`, otherwise fail with the underlying cause (`PlayerApplicationService.java`).
- Improved `BalanceApplicationService` error handling by introducing `unwrap(Throwable)` for nested async wrappers, using it in `isNotFoundException` and `throwAsCompletion` so `getBalance`/`getOrCreateBalance` behave as expected when futures fail (`BalanceApplicationService.java`).
- Changed `BalanceApiService` deposit and withdraw requests to include the query parameter `?amount=` in the request path so the outbound HTTP calls match the test expectations (`BalanceApiService.java`).
- Made `BalanceCommand` resilient to a `null` result from the `CurrencyFormatter` by adding `formatAmount(Long)` which falls back to `String.valueOf(amount)` when formatting is `null` (`BalanceCommand.java`).

### Testing
- Attempted to run `gradle test` with Java 21 via `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH=$JAVA_HOME/bin:$PATH gradle test --no-daemon`, but build execution was blocked by dependency resolution issues and network restrictions (remote Maven returned `403 Forbidden`).
- Attempted an offline run with `gradle test --no-daemon --offline`, but it failed because required dependencies were not cached locally so tests could not be executed.
- Targeted failing test suites that motivated these fixes: `BalanceApplicationServiceTest`, `PlayerApplicationServiceTest`, `BalanceApiServiceTest`, and `BalanceCommandTest`, but automated verification in this environment was not possible due to the dependency/network limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c31833fde88323a1412400d54d5e28)