### PR TITLE
Refactor pay flow: plugin-driven transfers and best-effort transaction logging

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationService.java
@@ -106,11 +106,23 @@ public class PayCommandApplicationService {
     }
 
     private CompletableFuture<PayExecutionResult> performTransfer(UUID payerUuid, UUID receiverUuid, long amount) {
-        return withdrawFromPayer(payerUuid, amount)
-                .thenCompose(v -> depositToReceiver(payerUuid, receiverUuid, amount))
-                .thenCompose(v -> logTransaction(payerUuid, receiverUuid, amount))
+        return executeBalanceTransfer(payerUuid, receiverUuid, amount)
+                .thenCompose(v -> logTransactionBestEffort(payerUuid, receiverUuid, amount))
                 .thenApply(v -> PayExecutionResult.success(receiverUuid))
                 .exceptionally(ex -> handleTransferException(ex, "transfer"));
+    }
+
+    /**
+     * Plugin-side source of truth for transfer execution.
+     * The transfer is always performed as:
+     * 1) Withdraw from payer
+     * 2) Deposit to receiver
+     *
+     * Any failure in step 2 triggers rollback logic.
+     */
+    private CompletableFuture<Void> executeBalanceTransfer(UUID payerUuid, UUID receiverUuid, long amount) {
+        return withdrawFromPayer(payerUuid, amount)
+                .thenCompose(v -> depositToReceiver(payerUuid, receiverUuid, amount));
     }
 
     private CompletableFuture<Void> withdrawFromPayer(UUID payerUuid, long amount) {
@@ -189,7 +201,11 @@ public class PayCommandApplicationService {
         };
     }
 
-    private CompletableFuture<Void> logTransaction(UUID payerUuid, UUID receiverUuid, long amount) {
+    /**
+     * Best-effort persistence/audit log.
+     * Logging failures must not rollback an already completed transfer.
+     */
+    private CompletableFuture<Void> logTransactionBestEffort(UUID payerUuid, UUID receiverUuid, long amount) {
         return transactionApi.register(payerUuid, receiverUuid, amount)
                 .thenApply(transaction -> (Void) null)  // Convert to Void
                 .exceptionally(ex -> {

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationServiceTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -134,9 +135,10 @@ class PayCommandApplicationServiceTest {
         verify(playerService).getCachedOrFetch(payerUuid, payerName);
         verify(playerApi).getPlayerByName(receiverName);
         verify(balanceApi).getBalance(payerUuid);
-        verify(balanceApi).withdraw(payerUuid, validAmount);
-        verify(balanceApi).deposit(receiverUuid, validAmount);
-        verify(transactionApi).register(payerUuid, receiverUuid, validAmount);
+        InOrder transferFlowOrder = inOrder(balanceApi, transactionApi);
+        transferFlowOrder.verify(balanceApi).withdraw(payerUuid, validAmount);
+        transferFlowOrder.verify(balanceApi).deposit(receiverUuid, validAmount);
+        transferFlowOrder.verify(transactionApi).register(payerUuid, receiverUuid, validAmount);
     }
 
     @Test
@@ -516,6 +518,7 @@ class PayCommandApplicationServiceTest {
 
         assertEquals(PayStatus.SUCCESS, result.getStatus());
         verify(transactionApi).register(payerUuid, receiverUuid, validAmount);
+        verify(balanceApi, never()).deposit(payerUuid, validAmount);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Ensure the plugin is the single source of truth for executing balance transfers while the transaction API is used only for persistence/audit logging to avoid double transfers and make behavior predictable.
- Preserve current rollback safety for partial failures (deposit failure must roll back withdrawal) and keep the async flow using `CompletableFuture`.

### Description
- Implemented plugin-driven transfer sequencing in `PayCommandApplicationService` by introducing `executeBalanceTransfer(...)` which performs `withdraw` then `deposit` via `balanceApi` and keeps rollback logic on deposit failure. (`java/src/main/java/.../PayCommandApplicationService.java`)
- Moved transaction persistence into a clearly named best-effort method `logTransactionBestEffort(...)` that calls `transactionApi.register` and logs a warning on failure without triggering any rollback. (`java/src/main/java/.../PayCommandApplicationService.java`)
- Updated `performTransfer(...)` to call `executeBalanceTransfer(...)` followed by `logTransactionBestEffort(...)`, ensuring the transfer execution order is `withdraw -> deposit -> register`.
- Adjusted tests in `PayCommandApplicationServiceTest` to verify the new ordering using `InOrder` and to assert that transaction logging failures do not cause a rollback to the payer.

### Testing
- Ran the unit test class `io.github.HenriqueMichelini.craftalism.economy.application.service.PayCommandApplicationServiceTest` via `./gradlew test --tests io.github.HenriqueMichelini.craftalism.economy.application.service.PayCommandApplicationServiceTest`.
- Automated test run could not complete in this environment due to a Gradle/JDK incompatibility error (`Unsupported class file major version 69`), so tests were not executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c32b081d6c8323a513a8e89266ec4a)