### PR TITLE
Update SetBalanceCommandTest to supply CurrencyFormatter dependency

### DIFF
--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
@@ -2,6 +2,7 @@ package io.github.HenriqueMichelini.craftalism.economy.presentation.commands;
 
 import io.github.HenriqueMichelini.craftalism.economy.application.dto.SetBalanceExecutionResult;
 import io.github.HenriqueMichelini.craftalism.economy.application.service.SetBalanceCommandApplicationService;
+import io.github.HenriqueMichelini.craftalism.economy.domain.service.currency.CurrencyFormatter;
 import io.github.HenriqueMichelini.craftalism.economy.domain.service.logs.messages.SetBalanceMessages;
 import io.github.HenriqueMichelini.craftalism.economy.presentation.validation.PlayerNameCheck;
 import org.bukkit.Bukkit;
@@ -18,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
@@ -38,6 +40,8 @@ class SetBalanceCommandTest {
     private JavaPlugin plugin;
     @Mock
     private Logger logger;
+    @Mock
+    private CurrencyFormatter formatter;
 
     @Mock
     private CommandSender sender;
@@ -56,13 +60,17 @@ class SetBalanceCommandTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
-        setBalanceCommand = new SetBalanceCommand(playerNameCheck, messages, service, plugin);
+        setBalanceCommand = new SetBalanceCommand(playerNameCheck, messages, service, plugin, formatter);
 
         when(sender.hasPermission(anyString())).thenReturn(true);
         when(senderPlayer.hasPermission(anyString())).thenReturn(true);
         when(senderPlayer.getName()).thenReturn("Admin");
         when(playerNameCheck.isValid(anyString())).thenReturn(true);
         when(plugin.getLogger()).thenReturn(logger);
+        when(formatter.fromDisplayValue(any(BigDecimal.class))).thenAnswer(invocation ->
+                invocation.<BigDecimal>getArgument(0).longValueExact());
+        when(formatter.formatCurrency(anyLong())).thenAnswer(invocation ->
+                String.valueOf(invocation.getArgument(0)));
 
         doAnswer(invocation -> {
             Runnable task = invocation.getArgument(1);


### PR DESCRIPTION
### Motivation
- The `SetBalanceCommand` constructor was changed to require a `CurrencyFormatter`, so the existing test instantiation used an undefined constructor signature. 

### Description
- Added an import for `CurrencyFormatter` and a `@Mock` field for it in `SetBalanceCommandTest`. 
- Updated the test setup to construct `SetBalanceCommand` with the new `formatter` mock (`new SetBalanceCommand(..., formatter)`).
- Stubbed `formatter.fromDisplayValue(...)` to convert a `BigDecimal` to `long` and `formatter.formatCurrency(...)` to return the numeric string so existing assertions remain valid.

### Testing
- Ran the unit test command `./gradlew test --tests io.github.HenriqueMichelini.craftalism.economy.presentation.commands.SetBalanceCommandTest`; the build failed in this environment due to a Java/Gradle runtime incompatibility error (`Unsupported class file major version 69`).
- No test failures related to the changed test logic were observed because the Gradle/JDK mismatch prevented the test run from completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38756d908832393fe6ba8174b7c4d)