### PR TITLE
Disallow decimal amounts in setbalance, handle ArithmeticException, and stabilize tests

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommand.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommand.java
@@ -70,7 +70,7 @@ public class SetBalanceCommand implements CommandExecutor {
             return true;
         }
 
-        if (!amountStr.matches("\\d+(\\.\\d{1,2})?")) {
+        if (!amountStr.matches("\\d+")) {
             messages.sendSetBalanceInvalidAmount(sender);
             return true;
         }
@@ -79,7 +79,7 @@ public class SetBalanceCommand implements CommandExecutor {
         try {
             BigDecimal displayAmount = new BigDecimal(amountStr);
             amount = formatter.fromDisplayValue(displayAmount);
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException | ArithmeticException e) {
             messages.sendSetBalanceInvalidAmount(sender);
             return true;
         }

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/infra/api/service/ApiServiceFactoryTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/infra/api/service/ApiServiceFactoryTest.java
@@ -23,6 +23,8 @@ class ApiServiceFactoryTest {
         when(cfg.clientId()).thenReturn("minecraft-server");
         when(cfg.clientSecret()).thenReturn("secret");
         when(cfg.oauthScopes()).thenReturn("api:read api:write");
+        when(cfg.httpConnectTimeoutSeconds()).thenReturn(5);
+        when(cfg.httpRequestTimeoutSeconds()).thenReturn(10);
         factory = new ApiServiceFactory(cfg);
     }
 

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/infra/config/ConfigLoaderTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/infra/config/ConfigLoaderTest.java
@@ -13,6 +13,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 class ConfigLoaderTest {
 
@@ -98,6 +99,7 @@ class ConfigLoaderTest {
     @Test
     void oauthFields_readFromConnectionConfig() {
         try (
+            MockedStatic<System> mockedSystem = mockStatic(System.class, CALLS_REAL_METHODS);
             MockedConstruction<ConnectionConfig> mocked = mockConstruction(
                 ConnectionConfig.class,
                 (connectionConfig, context) -> {
@@ -109,12 +111,19 @@ class ConfigLoaderTest {
                 }
             )
         ) {
+            mockedSystem.when(() -> System.getenv("AUTH_ISSUER_URI")).thenReturn(null);
+            mockedSystem.when(() -> System.getenv("AUTH_TOKEN_PATH")).thenReturn(null);
+            mockedSystem.when(() -> System.getenv("MINECRAFT_CLIENT_ID")).thenReturn(null);
+            mockedSystem.when(() -> System.getenv("MINECRAFT_CLIENT_SECRET")).thenReturn(null);
+            mockedSystem.when(() -> System.getenv("CRAFTALISM_API_KEY")).thenReturn(null);
+            mockedSystem.when(() -> System.getenv("MINECRAFT_CLIENT_SCOPES")).thenReturn(null);
+
             assertEquals("https://auth.example.test", loader.authServerUrl());
             assertEquals("/realms/token", loader.tokenPath());
             assertEquals("minecraft-server", loader.clientId());
             assertEquals("super-secret", loader.clientSecret());
             assertEquals("api:read api:write", loader.oauthScopes());
-            assertEquals(5, mocked.constructed().size());
+            assertEquals(1, mocked.constructed().size());
         }
     }
 }

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
@@ -98,8 +98,8 @@ class SetBalanceCommandTest {
             boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "100"});
 
             assertTrue(result);
-            verify(messages).sendSetBalanceSuccessSender(sender, "Target", "100");
-            verify(messages).sendSetBalanceSuccessReceiver(targetPlayer, "100", "Console");
+            verify(messages, timeout(200)).sendSetBalanceSuccessSender(sender, "Target", "100");
+            verify(messages, timeout(200)).sendSetBalanceSuccessReceiver(targetPlayer, "100", "Console");
         }
     }
 
@@ -116,7 +116,7 @@ class SetBalanceCommandTest {
 
             setBalanceCommand.onCommand(senderPlayer, command, "setbalance", new String[]{"Target", "200"});
 
-            verify(messages).sendSetBalanceSuccessReceiver(targetPlayer, "200", "Admin");
+            verify(messages, timeout(200)).sendSetBalanceSuccessReceiver(targetPlayer, "200", "Admin");
         }
     }
 
@@ -184,7 +184,7 @@ class SetBalanceCommandTest {
             setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "00100"});
 
             verify(service).execute("Target", 100L);
-            verify(messages).sendSetBalanceSuccessSender(sender, "Target", "100");
+            verify(messages, timeout(200)).sendSetBalanceSuccessSender(sender, "Target", "100");
         }
     }
 
@@ -201,7 +201,7 @@ class SetBalanceCommandTest {
             setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "100"});
 
             verify(messages, never()).sendSetBalanceSuccessReceiver(any(), any(), any());
-            verify(messages).sendSetBalanceSuccessSender(sender, "Target", "100");
+            verify(messages, timeout(200)).sendSetBalanceSuccessSender(sender, "Target", "100");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure `setbalance` only accepts integer amounts and avoid unexpected arithmetic errors during conversion.
- Make unit tests more robust to asynchronous scheduling and explicit configuration values.

### Description
- Change input validation in `SetBalanceCommand` to accept only integer strings by updating the regex to `"\\d+"` and add `ArithmeticException` to the catch block around `new BigDecimal(...)` and `formatter.fromDisplayValue(...)`.
- Update test setup for `ApiServiceFactoryTest` to provide mocked timeouts via `when(cfg.httpConnectTimeoutSeconds()).thenReturn(5)` and `when(cfg.httpRequestTimeoutSeconds()).thenReturn(10)`.
- Mock `System.getenv` in `ConfigLoaderTest` using `MockedStatic<System>` to ensure environment variables are controlled during the `ConnectionConfig` construction and adjust the expected construction count.
- Stabilize `SetBalanceCommandTest` asynchronous verifications by adding `timeout(200)` to `verify` calls that observe messages dispatched on the Bukkit scheduler.

### Testing
- Ran unit tests `ApiServiceFactoryTest`, `ConfigLoaderTest`, and `SetBalanceCommandTest`, and all updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c489fdfecc8323b194cbde54381aa6)