### PR TITLE
Add production-grade unit tests for SetBalanceCommand

### DIFF
--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java
@@ -1,0 +1,247 @@
+package io.github.HenriqueMichelini.craftalism.economy.presentation.commands;
+
+import io.github.HenriqueMichelini.craftalism.economy.application.dto.SetBalanceExecutionResult;
+import io.github.HenriqueMichelini.craftalism.economy.application.service.SetBalanceCommandApplicationService;
+import io.github.HenriqueMichelini.craftalism.economy.domain.service.currency.CurrencyFormatter;
+import io.github.HenriqueMichelini.craftalism.economy.domain.service.logs.messages.SetBalanceMessages;
+import io.github.HenriqueMichelini.craftalism.economy.presentation.validation.PlayerNameCheck;
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SetBalanceCommand tests")
+class SetBalanceCommandTest {
+
+    @Mock
+    private PlayerNameCheck playerNameCheck;
+    @Mock
+    private SetBalanceMessages messages;
+    @Mock
+    private SetBalanceCommandApplicationService service;
+    @Mock
+    private JavaPlugin plugin;
+    @Mock
+    private CurrencyFormatter formatter;
+    @Mock
+    private CommandSender sender;
+    @Mock
+    private Player senderPlayer;
+    @Mock
+    private Player receiver;
+    @Mock
+    private Command command;
+    @Mock
+    private BukkitScheduler scheduler;
+    @Mock
+    private BukkitTask task;
+    @Mock
+    private Logger logger;
+
+    private SetBalanceCommand setBalanceCommand;
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+
+        setBalanceCommand = new SetBalanceCommand(playerNameCheck, messages, service, plugin, formatter);
+
+        when(sender.hasPermission(anyString())).thenReturn(true);
+        when(senderPlayer.hasPermission(anyString())).thenReturn(true);
+        when(senderPlayer.getName()).thenReturn("AdminPlayer");
+
+        when(playerNameCheck.isValid(anyString())).thenReturn(true);
+        when(formatter.fromDisplayValue(any(BigDecimal.class))).thenReturn(1_2500L);
+        when(formatter.formatCurrency(anyLong())).thenReturn("$1.25");
+
+        when(plugin.getLogger()).thenReturn(logger);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
+    }
+
+    @Test
+    @DisplayName("should reject sender without permission")
+    void shouldRejectSenderWithoutPermission() {
+        when(sender.hasPermission(anyString())).thenReturn(false);
+
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "1"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceNoPermission(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should reject when args length is not exactly two")
+    void shouldRejectWhenArgsLengthIsInvalid() {
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceUsage(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should reject invalid target name")
+    void shouldRejectInvalidTargetName() {
+        when(playerNameCheck.isValid("Invalid@Name")).thenReturn(false);
+
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Invalid@Name", "10"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceInvalidName(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should reject non numeric amount")
+    void shouldRejectNonNumericAmount() {
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "10.5"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceInvalidAmount(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should reject amount when formatter conversion fails")
+    void shouldRejectAmountWhenFormatterConversionFails() {
+        when(formatter.fromDisplayValue(any(BigDecimal.class))).thenThrow(new ArithmeticException("overflow"));
+
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "99999999999999999999"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceInvalidAmount(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should reject negative amount after formatter conversion")
+    void shouldRejectNegativeAmountAfterFormatterConversion() {
+        when(formatter.fromDisplayValue(any(BigDecimal.class))).thenReturn(-1L);
+
+        boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "1"});
+
+        assertTrue(result);
+        verify(messages).sendSetBalanceInvalidAmount(sender);
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    @DisplayName("should send success messages to sender and online receiver for player sender")
+    void shouldSendSuccessMessagesToSenderAndOnlineReceiverForPlayerSender() {
+        UUID receiverUuid = UUID.randomUUID();
+        SetBalanceExecutionResult successResult = SetBalanceExecutionResult.success(1_2500L, receiverUuid);
+        when(service.execute("Target", 1_2500L)).thenReturn(CompletableFuture.completedFuture(successResult));
+        when(receiver.isOnline()).thenReturn(true);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+            bukkit.when(() -> Bukkit.getPlayer(receiverUuid)).thenReturn(receiver);
+            when(scheduler.runTask(eq(plugin), any(Runnable.class))).thenAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return task;
+            });
+
+            boolean result = setBalanceCommand.onCommand(senderPlayer, command, "setbalance", new String[]{"Target", "125"});
+
+            assertTrue(result);
+            verify(service).execute("Target", 1_2500L);
+            verify(messages).sendSetBalanceSuccessReceiver(receiver, "$1.25", "AdminPlayer");
+            verify(messages).sendSetBalanceSuccessSender(senderPlayer, "Target", "$1.25");
+        }
+    }
+
+    @Test
+    @DisplayName("should send success message only to sender when receiver uuid is absent")
+    void shouldSendSuccessMessageOnlyToSenderWhenReceiverUuidIsAbsent() {
+        SetBalanceExecutionResult successWithoutUuid = new SetBalanceExecutionResult(
+            io.github.HenriqueMichelini.craftalism.economy.domain.service.enums.SetBalanceStatus.SUCCESS,
+            java.util.Optional.of(1_2500L),
+            java.util.Optional.empty()
+        );
+        when(service.execute("Target", 1_2500L)).thenReturn(CompletableFuture.completedFuture(successWithoutUuid));
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+            when(scheduler.runTask(eq(plugin), any(Runnable.class))).thenAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return task;
+            });
+
+            boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "125"});
+
+            assertTrue(result);
+            verify(messages, never()).sendSetBalanceSuccessReceiver(any(), anyString(), anyString());
+            verify(messages).sendSetBalanceSuccessSender(sender, "Target", "$1.25");
+        }
+    }
+
+    @Test
+    @DisplayName("should map player not found status to proper message")
+    void shouldMapPlayerNotFoundStatusToProperMessage() {
+        when(service.execute("Target", 1_2500L)).thenReturn(CompletableFuture.completedFuture(SetBalanceExecutionResult.playerNotFound()));
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+            when(scheduler.runTask(eq(plugin), any(Runnable.class))).thenAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return task;
+            });
+
+            boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "125"});
+
+            assertTrue(result);
+            verify(messages).sendSetBalancePlayerNotFound(sender);
+            verify(messages, never()).sendSetBalanceSuccessSender(any(), anyString(), anyString());
+        }
+    }
+
+    @Test
+    @DisplayName("should handle unexpected async failure and notify sender")
+    void shouldHandleUnexpectedAsyncFailureAndNotifySender() {
+        RuntimeException failure = new RuntimeException("boom");
+        when(service.execute("Target", 1_2500L)).thenReturn(CompletableFuture.failedFuture(failure));
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+            when(scheduler.runTask(eq(plugin), any(Runnable.class))).thenAnswer(invocation -> {
+                Runnable runnable = invocation.getArgument(1);
+                runnable.run();
+                return task;
+            });
+
+            boolean result = setBalanceCommand.onCommand(sender, command, "setbalance", new String[]{"Target", "125"});
+
+            assertTrue(result);
+            verify(logger).severe(contains("Unexpected error in setbalance command"));
+            verify(messages).sendSetBalanceException(sender);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve confidence and maintainability of the command layer by exercising input validation, amount parsing, async orchestration and result-to-message mapping for `SetBalanceCommand`.
- Capture business-critical behaviors such as permission/usage guards, numeric-amount validation, formatter failure handling, negative amounts, and async success/failure branches.
- Make tests deterministic by mocking Bukkit static APIs and scheduler interactions to avoid flaky timing in async callbacks.

### Description
- Add `java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/commands/SetBalanceCommandTest.java` containing focused unit tests covering validation paths, amount parsing edge cases, and async result handling.
- Use Mockito (including `MockedStatic` for `Bukkit`) to stub scheduler behavior so `runTask` executes the callback immediately and to stub `Bukkit.getPlayer(...)` for receiver delivery tests.
- Verify successful flows send sender and receiver messages when appropriate, verify mapping of `PLAYER_NOT_FOUND`, and verify async exceptional completion logs a severe message and notifies the sender.
- Include tests for non-numeric input, formatter conversion failures (throwing `ArithmeticException`), and negative amount detection after conversion.

### Testing
- Attempted to run the new test class with `cd java && ./gradlew test --tests io.github.HenriqueMichelini.craftalism.economy.presentation.commands.SetBalanceCommandTest`, but the build failed due to an environment JDK/Gradle incompatibility: `Unsupported class file major version 69` (Gradle/JDK mismatch), so automated tests could not be executed in this environment.
- The test suite is deterministic and avoids sleeps by executing scheduled runnables synchronously via the mocked `BukkitScheduler`, so it should run stably under a compatible local CI/JDK setup.
- No other automated tests were modified; this PR only adds the new test class.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c507df19f483239cfd1a6c3eb712f2)