### PR TITLE
Refine application-layer boundaries and async error handling

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/ApplicationServiceFactory.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/ApplicationServiceFactory.java
@@ -33,7 +33,7 @@ public final class ApplicationServiceFactory {
                 apis.getPlayerApi(),
                 apis.getBalanceApi(),
                 apis.getTransactionApi(),
-                plugin
+                plugin.getLogger()
         );
 
         this.balanceCmdApp = new BalanceCommandApplicationService(playerApp, balanceApp);

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 
 public class BalanceApplicationService {
 
@@ -48,15 +47,7 @@ public class BalanceApplicationService {
         return api
             .getBalance(uuid)
             .exceptionallyCompose(ex -> {
-                Throwable cause = ex;
-                while (
-                    cause.getCause() != null &&
-                    (cause instanceof CompletionException ||
-                        cause instanceof
-                            java.util.concurrent.ExecutionException)
-                ) {
-                    cause = cause.getCause();
-                }
+                Throwable cause = AsyncExceptionResolver.unwrap(ex);
 
                 if (cause instanceof NotFoundException) {
                     return api.createBalance(uuid, DEFAULT_VALUE);
@@ -106,24 +97,10 @@ public class BalanceApplicationService {
     }
 
     private boolean isNotFoundException(Throwable ex) {
-        return unwrap(ex) instanceof NotFoundException;
-    }
-
-    private Throwable unwrap(Throwable throwable) {
-        Throwable current = throwable;
-        while (
-            current instanceof CompletionException ||
-            current instanceof ExecutionException
-        ) {
-            if (current.getCause() == null) {
-                break;
-            }
-            current = current.getCause();
-        }
-        return current;
+        return AsyncExceptionResolver.unwrap(ex) instanceof NotFoundException;
     }
 
     private <T> T throwAsCompletion(Throwable ex) {
-        throw new CompletionException(unwrap(ex));
+        throw new CompletionException(AsyncExceptionResolver.unwrap(ex));
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceCommandApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceCommandApplicationService.java
@@ -39,7 +39,7 @@ public class BalanceCommandApplicationService {
     }
 
     private BalanceExecutionResult handleOtherError(Throwable ex) {
-        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+        Throwable cause = AsyncExceptionResolver.unwrap(ex);
 
         if (cause instanceof NotFoundException) {
             return BalanceExecutionResult.notFound();

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationService.java
@@ -8,30 +8,30 @@ import io.github.HenriqueMichelini.craftalism.economy.infra.api.exceptions.NotFo
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.BalanceApiService;
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.PlayerApiService;
 import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.TransactionApiService;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
 
 public class PayCommandApplicationService {
     private final PlayerApplicationService playerService;
     private final PlayerApiService playerApi;
     private final BalanceApiService balanceApi;
     private final TransactionApiService transactionApi;
-    private final JavaPlugin plugin;
+    private final Logger logger;
 
     public PayCommandApplicationService(
             PlayerApplicationService playerService,
             PlayerApiService playerApi,
             BalanceApiService balanceApi,
             TransactionApiService transactionApi,
-            JavaPlugin plugin
+            Logger logger
     ) {
         this.playerService = playerService;
         this.playerApi = playerApi;
         this.balanceApi = balanceApi;
         this.transactionApi = transactionApi;
-        this.plugin = plugin;
+        this.logger = logger;
     }
 
     public CompletableFuture<PayExecutionResult> execute(
@@ -262,35 +262,35 @@ public class PayCommandApplicationService {
     }
 
     private void logInfo(String message) {
-        if (plugin != null) {
-            plugin.getLogger().info(message);
+        if (logger != null) {
+            logger.info(message);
         }
     }
 
     private void logWarning(String message) {
-        if (plugin != null) {
-            plugin.getLogger().warning(message);
+        if (logger != null) {
+            logger.warning(message);
         }
     }
 
     private void logError(String message, Throwable ex) {
-        if (plugin != null) {
-            plugin.getLogger().severe(message + ": " + ex.getMessage());
+        if (logger != null) {
+            logger.severe(message + ": " + ex.getMessage());
             if (ex.getCause() != null) {
-                plugin.getLogger().severe("Caused by: " + ex.getCause().getMessage());
+                logger.severe("Caused by: " + ex.getCause().getMessage());
             }
         }
     }
 
     private void logCritical(String message, Throwable ex) {
-        if (plugin != null) {
-            plugin.getLogger().severe("***** CRITICAL ERROR *****");
-            plugin.getLogger().severe(message);
-            plugin.getLogger().severe("Exception: " + ex.getMessage());
+        if (logger != null) {
+            logger.severe("***** CRITICAL ERROR *****");
+            logger.severe(message);
+            logger.severe("Exception: " + ex.getMessage());
             if (ex.getCause() != null) {
-                plugin.getLogger().severe("Caused by: " + ex.getCause().getMessage());
+                logger.severe("Caused by: " + ex.getCause().getMessage());
             }
-            plugin.getLogger().severe("***** END CRITICAL ERROR *****");
+            logger.severe("***** END CRITICAL ERROR *****");
         }
     }
 

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
@@ -10,8 +10,6 @@ import io.github.HenriqueMichelini.craftalism.economy.infra.api.service.PlayerAp
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 
 public class PlayerApplicationService {
     private final PlayerApiService api;
@@ -74,7 +72,7 @@ public class PlayerApplicationService {
     public CompletableFuture<PlayerResponseDTO> getOrCreatePlayer(UUID uuid, String name) {
         return api.getPlayerByUuid(uuid)
                 .exceptionallyCompose(ex -> {
-                    Throwable cause = unwrap(ex);
+                    Throwable cause = AsyncExceptionResolver.unwrap(ex);
                     if (cause instanceof NotFoundException || cause instanceof ApiServerException) {
                         return api.createPlayer(uuid, name);
                     }
@@ -94,16 +92,5 @@ public class PlayerApplicationService {
                     cache.save(player);
                     return player;
                 });
-    }
-
-    private Throwable unwrap(Throwable throwable) {
-        Throwable current = throwable;
-        while (current instanceof CompletionException || current instanceof ExecutionException) {
-            if (current.getCause() == null) {
-                break;
-            }
-            current = current.getCause();
-        }
-        return current;
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/SetBalanceCommandApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/SetBalanceCommandApplicationService.java
@@ -41,7 +41,12 @@ public class SetBalanceCommandApplicationService {
     private CompletableFuture<SetBalanceExecutionResult> setBalanceForPlayer(UUID uuid, long amount) {
         return balanceApi.updateBalance(uuid, amount)
                 .thenApply(v -> SetBalanceExecutionResult.success(amount, uuid))
-                .exceptionally(ex -> SetBalanceExecutionResult.updateFailed());
+                .exceptionally(ex -> {
+                    if (AsyncExceptionResolver.isCausedBy(ex, NotFoundException.class)) {
+                        return SetBalanceExecutionResult.playerNotFound();
+                    }
+                    return SetBalanceExecutionResult.updateFailed();
+                });
     }
 
     private SetBalanceExecutionResult handleException(Throwable exception) {

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/TransactionApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/TransactionApplicationService.java
@@ -39,14 +39,14 @@ public class TransactionApplicationService {
     public CompletableFuture<Transaction> registerTransactionWithRetry(UUID from, UUID to, long amount) {
         return api.register(from, to, amount)
                 .exceptionallyCompose(ex -> {
-                    Throwable cause = unwrapException(ex);
+                    Throwable cause = AsyncExceptionResolver.unwrap(ex);
 
                     if (cause instanceof RateLimitException) {
                         // Could implement retry logic here if needed
-                        return CompletableFuture.failedFuture(ex);
+                        return CompletableFuture.failedFuture(cause);
                     }
 
-                    return CompletableFuture.failedFuture(ex);
+                    return CompletableFuture.failedFuture(cause);
                 })
                 .thenApply(this::toTransaction);
     }
@@ -56,12 +56,7 @@ public class TransactionApplicationService {
     }
 
     private Throwable unwrapException(Throwable ex) {
-        Throwable cause = ex;
-        while (cause.getCause() != null &&
-                (cause instanceof CompletionException || cause instanceof java.util.concurrent.ExecutionException)) {
-            cause = cause.getCause();
-        }
-        return cause;
+        return AsyncExceptionResolver.unwrap(ex);
     }
 
     private boolean isNotFoundException(Throwable ex) {
@@ -73,6 +68,6 @@ public class TransactionApplicationService {
     }
 
     private <T> T throwAsCompletion(Throwable ex) {
-        throw new CompletionException(ex);
+        throw new CompletionException(unwrapException(ex));
     }
 }

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationServiceTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PayCommandApplicationServiceTest.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,9 +42,6 @@ class PayCommandApplicationServiceTest {
     private TransactionApiService transactionApi;
 
     @Mock
-    private JavaPlugin plugin;
-
-    @Mock
     private java.util.logging.Logger logger;
 
     private PayCommandApplicationService service;
@@ -63,14 +59,13 @@ class PayCommandApplicationServiceTest {
     @BeforeEach
     void setUp() {
         mocks = MockitoAnnotations.openMocks(this);
-        when(plugin.getLogger()).thenReturn(logger);
 
         service = new PayCommandApplicationService(
             playerService,
             playerApi,
             balanceApi,
             transactionApi,
-            plugin
+            logger
         );
 
         payerUuid = UUID.randomUUID();


### PR DESCRIPTION
### Motivation
- Remove framework leakage from the application layer and make async exception handling deterministic and consistent across services.
- Fix incorrect error classification in an edge path so command results map to the correct domain status.

### Description
- Replaced direct `JavaPlugin` dependency in `PayCommandApplicationService` with a plain `Logger` and moved framework-to-logger mapping to the composition root by passing `plugin.getLogger()` from `ApplicationServiceFactory`.
- Standardized async exception unwrapping by using `AsyncExceptionResolver.unwrap` (and `isCausedBy`) in `BalanceApplicationService`, `PlayerApplicationService`, `TransactionApplicationService`, and `BalanceCommandApplicationService` to avoid duplicated/fragile unwrap logic.
- Adjusted `SetBalanceCommandApplicationService` to map `NotFoundException` returned from `balanceApi.updateBalance` to `playerNotFound()` instead of `updateFailed()` to handle race/consistency scenarios correctly.
- Updated `PayCommandApplicationServiceTest` to inject a `Logger` (reflecting the constructor change) and updated small error-handling code paths to use the resolver utilities.

### Testing
- Attempted to run application-layer tests with: `cd java && ./gradlew test --tests 'io.github.HenriqueMichelini.craftalism.economy.application.service.*'`.
- Tests could not be executed in this environment because the build failed due to toolchain incompatibility (`Unsupported class file major version 69`), so no test failures from the modified code were observed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50cd455ec83239af548abf8f2a345)