### PR TITLE
Fix quit listener wiring and add plugin shutdown cache cleanup

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/ApplicationServiceFactory.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/ApplicationServiceFactory.java
@@ -70,6 +70,7 @@ public final class ApplicationServiceFactory {
     }
 
     public void shutdown() {
-        // persist caches, shutdown http client, etc.
+        playerApp.clearCache();
+        balanceApp.clearCache();
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/BalanceApplicationService.java
@@ -103,4 +103,8 @@ public class BalanceApplicationService {
     private <T> T throwAsCompletion(Throwable ex) {
         throw new CompletionException(AsyncExceptionResolver.unwrap(ex));
     }
+
+    public void clearCache() {
+        cache.clear();
+    }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/application/service/PlayerApplicationService.java
@@ -93,4 +93,12 @@ public class PlayerApplicationService {
                     return player;
                 });
     }
+
+    public void evictCachedPlayer(UUID uuid) {
+        cache.delete(uuid);
+    }
+
+    public void clearCache() {
+        cache.clear();
+    }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/infra/config/bootstrap/BootContainer.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/infra/config/bootstrap/BootContainer.java
@@ -32,6 +32,7 @@ public final class BootContainer {
 
     private PlayerApplicationService playerApplicationService;
     private BalanceApplicationService balanceApplicationService;
+    private ApplicationServiceFactory applicationServiceFactory;
 
     public BootContainer(CraftalismEconomy plugin, JavaPlugin javaPlugin) {
         this.plugin = plugin;
@@ -55,6 +56,7 @@ public final class BootContainer {
 
         long defaultBalance = configLoader.defaultBalance();
         ApplicationServiceFactory appFactory = new ApplicationServiceFactory(javaPlugin, apiFactory, defaultBalance);
+        this.applicationServiceFactory = appFactory;
 
         this.playerApplicationService = appFactory.getPlayerApplication();
         this.balanceApplicationService = appFactory.getBalanceApplication();
@@ -64,7 +66,9 @@ public final class BootContainer {
     }
 
     public void shutdown() {
-        // flush caches, send pending balances, etc
+        if (applicationServiceFactory != null) {
+            applicationServiceFactory.shutdown();
+        }
     }
 
     public CurrencyFormatter getCurrencyFormatter() {

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/EventRegistrar.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/EventRegistrar.java
@@ -24,5 +24,9 @@ public class EventRegistrar {
                 new OnJoin(playerApplicationService, balanceApplicationService),
                 plugin
         );
+        plugin.getServer().getPluginManager().registerEvents(
+                new OnQuit(playerApplicationService),
+                plugin
+        );
     }
 }

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/OnQuit.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/OnQuit.java
@@ -1,25 +1,24 @@
 package io.github.HenriqueMichelini.craftalism.economy.presentation.listeners;
 
-import io.github.HenriqueMichelini.craftalism.economy.infra.api.repository.PlayerCacheRepository;
+import io.github.HenriqueMichelini.craftalism.economy.application.service.PlayerApplicationService;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.UUID;
 
-public class OnQuit {
-    private final PlayerCacheRepository cache;
+public class OnQuit implements Listener {
+    private final PlayerApplicationService playerService;
 
-    public OnQuit(PlayerCacheRepository cache) {
-        this.cache = cache;
+    public OnQuit(PlayerApplicationService playerService) {
+        this.playerService = playerService;
     }
 
     @EventHandler
-    public void OnPlayerQuit(PlayerJoinEvent event) {
+    public void onPlayerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
-
         UUID uuid = player.getUniqueId();
-
-        cache.delete(uuid);
+        playerService.evictCachedPlayer(uuid);
     }
 }

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/OnQuitTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/economy/presentation/listeners/OnQuitTest.java
@@ -1,0 +1,31 @@
+package io.github.HenriqueMichelini.craftalism.economy.presentation.listeners;
+
+import io.github.HenriqueMichelini.craftalism.economy.application.service.PlayerApplicationService;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OnQuitTest {
+
+    @Test
+    void shouldEvictPlayerCacheOnQuit() {
+        PlayerApplicationService playerService = mock(PlayerApplicationService.class);
+        PlayerQuitEvent event = mock(PlayerQuitEvent.class);
+        Player player = mock(Player.class);
+        UUID playerUuid = UUID.randomUUID();
+
+        when(event.getPlayer()).thenReturn(player);
+        when(player.getUniqueId()).thenReturn(playerUuid);
+
+        OnQuit listener = new OnQuit(playerService);
+        listener.onPlayerQuit(event);
+
+        verify(playerService).evictCachedPlayer(playerUuid);
+    }
+}


### PR DESCRIPTION
### Motivation
- The audit correctly identified that the quit listener was broken and never ran, so player cache eviction on quit was non-functional.
- The plugin lifecycle shutdown path was a placeholder, so in-memory caches were never deterministically cleaned on disable.

### Description
- Implemented a real quit listener: `OnQuit` now `implements Listener`, handles `PlayerQuitEvent`, and calls `PlayerApplicationService.evictCachedPlayer(UUID)`. 
- Wired the listener: `EventRegistrar.registerAll()` now registers `OnQuit` so quit events are actually handled at runtime. 
- Added cache management APIs: `PlayerApplicationService.evictCachedPlayer(UUID)` and `clearCache()` and `BalanceApplicationService.clearCache()` so caches can be cleared from a central shutdown path. 
- Implemented shutdown cleanup: `ApplicationServiceFactory.shutdown()` clears player and balance caches and `BootContainer.shutdown()` invokes it. 
- Added `OnQuitTest` unit test to verify that `OnQuit.onPlayerQuit()` invokes cache eviction on the `PlayerApplicationService`.

### Testing
- Added unit test `java/src/test/java/.../OnQuitTest.java` which asserts the quit listener calls `evictCachedPlayer`, and the test file is included in the repository. 
- Attempted to run the test suite with `./gradlew test`, but the build failed to start due to an environment/toolchain issue (`Unsupported class file major version 69`), so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d047c27ec08323be3ec1675092bd53)